### PR TITLE
Set empty access filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,13 @@ Example code to use the Ruby Embed SSO API in various languages
  LOOKER_EMBED_SECRET=${LOOKER_EMBED_SECRET} FLEXE_COMPANY_ID=${PRODUCTION_COMPANY_ID} ruby flexe_example.rb
  ```  
  
+ or 
+ 
+ ```bash
+ export LOOKER_EMBED_SECRET=${LOOKER_EMBED_SECRET}
+ export FLEXE_COMPANY_ID=${PRODUCTION_COMPANY_ID}
+ ruby flexe_example.rb
+ ```
+ 
  If url renders a dashboard specific to that company id then we are all set
 

--- a/flexe_example.rb
+++ b/flexe_example.rb
@@ -18,7 +18,7 @@ def example_1
       permissions:        ['access_data', 'see_looks', 'see_user_dashboards'],
       models:             ['flexe_data'],
       user_attributes:    {"company_id" => company_id},
-      # access_filters:     {:fake_model => {:id => 1}},
+      access_filters:     {},
       session_length:     fifteen_minutes,
       embed_url:          "/embed/dashboards/9",
       force_logout_login: false


### PR DESCRIPTION
Provide empty access_filters because it is a required field.